### PR TITLE
feat: add configurable spool start delay

### DIFF
--- a/src/main/bx/ModuleConfig.bx
+++ b/src/main/bx/ModuleConfig.bx
@@ -82,6 +82,10 @@ class {
 			spoolEnable : true,
 			// Spool interval, in minutes
 			spoolInterval : .50,
+			// Delay (minutes) before the internal spool drainer first runs, to gate a
+			// fresh container during rolling deploys so it doesn't drain a shared spool
+			// while the previous container is still up. Default 0 = no delay.
+			spoolStartDelayMinutes : 0,
 			connectionTimeout : nullValue(),
 			downloadUndeliveredAttachments: false,
 			signMesssage: false,

--- a/src/main/java/ortus/boxlang/modules/mail/schedulers/SpoolScheduler.java
+++ b/src/main/java/ortus/boxlang/modules/mail/schedulers/SpoolScheduler.java
@@ -94,9 +94,11 @@ public class SpoolScheduler extends BaseScheduler {
 		}
 
 		long spoolIntervalMillis = LongCaster.cast( DoubleCaster.cast( moduleSettings.get( MailKeys.spoolInterval ) ) * minuteToMilisMulitplier );
+		long spoolStartDelayMillis = LongCaster.cast( DoubleCaster.cast( moduleSettings.get( MailKeys.spoolStartDelayMinutes ) ) * minuteToMilisMulitplier );
 
 		task( "SpoolTask" )
 		    .call( SpoolScheduler::processSpool )
+		    .delay( spoolStartDelayMillis, TimeUnit.MILLISECONDS )
 		    .every( spoolIntervalMillis, TimeUnit.MILLISECONDS )
 		    .setNoOverlaps( true )
 		    .onFailure( SpoolScheduler::onSpoolFailure )

--- a/src/main/java/ortus/boxlang/modules/mail/util/MailKeys.java
+++ b/src/main/java/ortus/boxlang/modules/mail/util/MailKeys.java
@@ -76,6 +76,7 @@ public class MailKeys {
 	public static final Key	SMTP					= Key.of( "SMTP" );
 	public static final Key	spoolEnable				= Key.of( "spoolEnable" );
 	public static final Key	spoolInterval			= Key.of( "spoolInterval" );
+	public static final Key	spoolStartDelayMinutes	= Key.of( "spoolStartDelayMinutes" );
 	public static final Key	spoolDirectory			= Key.of( "spoolDirectory" );
 	public static final Key	spoolTimeout			= Key.of( "spoolTimeout" );
 	public static final Key	success					= Key.of( "success" );


### PR DESCRIPTION

# Description

Add a new module setting, spoolStartDelayMinutes (default 0), that delays the first run of the internal SpoolTask drainer. This lets a freshly started container wait out a rolling-deploy overlap before draining a shared, bind-mounted spool directory, preventing duplicate sends while the previous container is still draining.

The delay is applied via ScheduledTask.delay(long, TimeUnit) and counts in minutes for consistency with spoolInterval.

**Please note that all PRs must have tests attached to them**

## Jira/Github Issues

https://ortussolutions.atlassian.net/browse/BLMODULES-276

## Type of change

- [X] New Feature

## Checklist

- [X] My code follows the style guidelines of this project [cfformat](../.cfformat.json) and [Java](../ortus-java-style.xml)
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works (not sure how to test this one but happy to try if you like)
- [X] New and existing unit tests pass locally with my changes
